### PR TITLE
docs: clarify connection pooling in createClient and fix broken link …

### DIFF
--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -25,7 +25,7 @@
 | disableOfflineQueue          | `false`                                  | Disables offline queuing, see [FAQ](./FAQ.md#what-happens-when-the-network-goes-down)                                                                                                                                                               |
 | readonly                     | `false`                                  | Connect in [`READONLY`](https://redis.io/commands/readonly) mode                                                                                                                                                                                    |
 | legacyMode                   | `false`                                  | Maintain some backwards compatibility (see the [Migration Guide](./v3-to-v4.md))                                                                                                                                                                    |
-| isolationPoolOptions         |                                          | See the [Isolated Execution Guide](./isolated-execution.md)                                                                                                                                                                                         |
+| isolationPoolOptions         |                                          | An object that configures a pool of isolated connections, If you frequently need isolated connections, consider using [createClientPool](https://github.com/redis/node-redis/blob/master/docs/pool.md#creating-a-pool) instead                                                                                                     |
 | pingInterval                 |                                          | Send `PING` command at interval (in ms). Useful with ["Azure Cache for Redis"](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-best-practices-connection#idle-timeout)                                                          |
 
 ## Reconnect Strategy
@@ -81,3 +81,9 @@ createClient({
   }
 });
 ```
+## Connection Pooling
+
+In most cases, a single Redis connection is sufficient, as the node-redis client efficiently handles commands using an underlying socket. Unlike traditional databases, Redis does not require connection pooling for optimal performance.
+
+However, if your use case requires exclusive connections see [RedisClientPool](https://github.com/redis/node-redis/blob/master/docs/pool.md), which allows you to create and manage multiple dedicated connections.
+


### PR DESCRIPTION
### Description
This PR improves the [`createClient`](https://github.com/redis/node-redis/blob/master/docs/client-configuration.md) documentation by:

- Adding a Connection Pooling section to clarify that a single connection is usually sufficient for Redis and directing users to [RedisClientPool](https://github.com/redis/node-redis/blob/master/docs/pool.md) for scenarios requiring connection pooling.
- Updating `isolationPoolOptions` to provide a clearer explanation and replacing the [broken link](https://github.com/redis/node-redis/blob/master/docs/isolated-execution.md) with a reference to [`createClientPool`.](https://github.com/redis/node-redis/blob/master/docs/pool.md#creating-a-pool)
- These updates help address [#2845](https://github.com/redis/node-redis/issues/2845).

